### PR TITLE
Bug/#15908 cannot specify management interface

### DIFF
--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -67,26 +67,23 @@ unless network.nil? # network will not be defined in cloud deployments
       f.puts "ONBOOT=yes"
       dev_uuid = File.read("/proc/sys/kernel/random/uuid").chomp
       f.puts "UUID=#{dev_uuid}"
-
-      if dev == management_interface && iface_mode != 'dhcp'
-        f.puts "IPADDR=#{iface['ip']}" if iface['ip']
-        f.puts "NETMASK=#{iface['netmask']}" if iface['netmask']
-        f.puts "GATEWAY=#{iface['gateway']}" if iface['gateway']
-      elsif iface_mode != 'dhcp'
-        if Config_utils.check_ipv4({:ip => iface['ip'], :netmask => iface['netmask']})  and Config_utils.check_ipv4(:ip => iface['gateway'])
-          f.puts "IPADDR=#{iface['ip']}"
-          f.puts "NETMASK=#{iface['netmask']}"
-          f.puts "GATEWAY=#{iface['gateway']}" unless iface['gateway'].nil?
+      
+      if iface_mode != 'dhcp'
+        # Specific handling for static and management interfaces
+        if dev == management_interface || Config_utils.check_ipv4(ip: iface['ip'], netmask: iface['netmask'], gateway: iface['gateway'])
+          f.puts "IPADDR=#{iface['ip']}" if iface['ip']
+          f.puts "NETMASK=#{iface['netmask']}" if iface['netmask']
+          f.puts "GATEWAY=#{iface['gateway']}" if iface['gateway']
+          f.puts "DEFROUTE=yes" if dev == management_interface
         else
           p err_msg = "Invalid network configuration for device #{dev}. Please review #{INITCONF} file"
           exit 1
         end
+      else
+        # Specific settings for DHCP
+        f.puts "PEERDNS=no"
+        f.puts "DEFROUTE=no" unless dev == management_interface
       end
-      dev_uuid = File.read("/proc/sys/kernel/random/uuid").chomp
-      f.puts "BOOTPROTO=#{iface_mode}"
-      f.puts "DEVICE=#{dev}"
-      f.puts "ONBOOT=yes"
-      f.puts "UUID=#{dev_uuid}"
     }
   end
 

--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -74,7 +74,11 @@ unless network.nil? # network will not be defined in cloud deployments
           f.puts "IPADDR=#{iface['ip']}" if iface['ip']
           f.puts "NETMASK=#{iface['netmask']}" if iface['netmask']
           f.puts "GATEWAY=#{iface['gateway']}" if iface['gateway']
-          f.puts "DEFROUTE=yes" if dev == management_interface
+          if dev == management_interface
+            f.puts "DEFROUTE=yes"
+          else
+            f.puts "DEFROUTE=no"
+          end
         else
           p err_msg = "Invalid network configuration for device #{dev}. Please review #{INITCONF} file"
           exit 1

--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -24,6 +24,8 @@ cloud_address = init_conf['cloud_address']
 
 network = init_conf['network']
 
+management_interface = init_conf['network']['management_interface'] if init_conf['network'] && init_conf['network']['management_interface']
+
 # Create file with bash env variables
 open("/etc/redborder/rb_init_conf.conf", "w") { |f|
   f.puts "#REDBORDER ENV VARIABLES"

--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -62,7 +62,17 @@ unless network.nil? # network will not be defined in cloud deployments
     dev = iface['device']
     iface_mode = iface['mode']
     open("/etc/sysconfig/network-scripts/ifcfg-#{dev}", 'w') { |f|
-      if iface_mode != 'dhcp'
+      f.puts "BOOTPROTO=#{iface_mode}"
+      f.puts "DEVICE=#{dev}"
+      f.puts "ONBOOT=yes"
+      dev_uuid = File.read("/proc/sys/kernel/random/uuid").chomp
+      f.puts "UUID=#{dev_uuid}"
+
+      if dev == management_interface && iface_mode != 'dhcp'
+        f.puts "IPADDR=#{iface['ip']}" if iface['ip']
+        f.puts "NETMASK=#{iface['netmask']}" if iface['netmask']
+        f.puts "GATEWAY=#{iface['gateway']}" if iface['gateway']
+      elsif iface_mode != 'dhcp'
         if Config_utils.check_ipv4({:ip => iface['ip'], :netmask => iface['netmask']})  and Config_utils.check_ipv4(:ip => iface['gateway'])
           f.puts "IPADDR=#{iface['ip']}"
           f.puts "NETMASK=#{iface['netmask']}"

--- a/resources/scripts/rb_setup_wizard.rb
+++ b/resources/scripts/rb_setup_wizard.rb
@@ -13,21 +13,15 @@ if File.exist?(DIALOGRC)
 end
 
 def cancel_wizard()
-
     dialog = MRDialog.new
     dialog.clear = true
     dialog.title = "SETUP wizard cancelled"
-
     text = <<EOF
-
 The setup has been cancelled or stopped.
-
 If you want to complete the setup wizard, please execute it again.
-
 EOF
     result = dialog.msgbox(text, 11, 41)
     exit(1)
-
 end
 
 puts "\033]0;redborder - setup wizard\007"
@@ -37,42 +31,33 @@ general_conf = {
     "network" => {
         "interfaces" => [],
         "dns" => []
-        }
     }
+}
 
 # general_conf will dump its contents as yaml conf into rb_init_conf.yml
 
-# TODO: intro to the wizard, define color set, etc.
-
 text = <<EOF
-
 This wizard will guide you through the necessary configuration of the device
 in order to convert it into a redborder node within a redborder cluster.
-
 It will go through the following required steps: network configuration,
 configuration of hostname, domain and DNS, Serf configuration, and finally
 the node mode (the mode determines the minimum group of services that make up
 the node, giving it more or less weight within the cluster).
-
 Would you like to continue?
-
 EOF
 
 dialog = MRDialog.new
 dialog.clear = true
 dialog.title = "Configure wizard"
-yesno = dialog.yesno(text,0,0)
+yesno = dialog.yesno(text, 0, 0)
 
 cancel_wizard unless yesno # yesno is "yes" -> true
 
 text = <<EOF
-
 Next, you will be able to configure network settings. If you have
 the network configured manually, you can "SKIP" this step and go
 to the next step.
-
 Please, Select an option.
-
 EOF
 
 dialog = MRDialog.new
@@ -80,7 +65,7 @@ dialog.clear = true
 dialog.title = "Configure Network"
 dialog.cancel_label = "SKIP"
 dialog.no_label = "SKIP"
-yesno = dialog.yesno(text,0,0)
+yesno = dialog.yesno(text, 0, 0)
 
 if yesno # yesno is "yes" -> true
     # Conf for network
@@ -89,21 +74,38 @@ if yesno # yesno is "yes" -> true
     cancel_wizard if netconf.cancel
     general_conf["network"]["interfaces"] = netconf.conf
 
+    # AQUÍ INICIA EL NUEVO CÓDIGO PARA SELECCIONAR LA INTERFAZ DE GESTIÓN
+    if general_conf["network"]["interfaces"].size > 1
+        interface_options = general_conf["network"]["interfaces"].map { |i| i["device"] }
+        text = <<EOF
+You have multiple network interfaces configured.
+Please select one to be used as the management interface.
+EOF
+        dialog = MRDialog.new
+        dialog.clear = true
+        dialog.title = "Select Management Interface"
+        management_iface = dialog.menu(text, interface_options, 0, 0)
+
+        if management_iface.nil? || management_iface.empty?
+            cancel_wizard
+        else
+            general_conf["network"]["management_interface"] = management_iface
+        end
+    end
+    # AQUÍ TERMINA EL NUEVO CÓDIGO
+
     # Conf for DNS
     text = <<EOF
-
 Do you want to configure DNS servers?
-
 If you have configured the network as Dynamic and
 you get the DNS servers via DHCP, you should say
-'No' to this  question.
-
+'No' to this question.
 EOF
 
     dialog = MRDialog.new
     dialog.clear = true
     dialog.title = "CONFIGURE DNS"
-    yesno = dialog.yesno(text,0,0)
+    yesno = dialog.yesno(text, 0, 0)
 
     if yesno # yesno is "yes" -> true
         # configure dns
@@ -124,12 +126,10 @@ general_conf["cloud_address"] = cloud_address_conf.conf[:cloud_address]
 
 # Confirm
 text = <<EOF
-
 You have selected the following parameter values for your configuration:
-
 EOF
 
-#Get interfaces info
+# Get interfaces info
 unless general_conf["network"]["interfaces"].empty?
     text += "- Networking:\n"
     general_conf["network"]["interfaces"].each do |i|
@@ -146,7 +146,7 @@ unless general_conf["network"]["interfaces"].empty?
     end
 end
 
-#Get DNS info
+# Get DNS info
 unless general_conf["network"]["dns"].nil?
     text += "- DNS:\n"
     general_conf["network"]["dns"].each do |dns|
@@ -161,16 +161,15 @@ text += "\nPlease, is this configuration ok?\n \n"
 dialog = MRDialog.new
 dialog.clear = true
 dialog.title = "Confirm configuration"
-yesno = dialog.yesno(text,0,0)
+yesno = dialog.yesno(text, 0, 0)
 
 cancel_wizard unless yesno # yesno is "yes" -> true
 
-File.open(CONFFILE, 'w') {|f| f.write general_conf.to_yaml } #Store
+File.open(CONFFILE, 'w') { |f| f.write general_conf.to_yaml } # Store
 
-#exec("#{ENV['RBBIN']}/rb_init_conf.sh")
+# Executing rb_init_conf
 command = "#{ENV['RBBIN']}/rb_init_conf"
-
 dialog = MRDialog.new
 dialog.clear = false
 dialog.title = "Applying configuration"
-dialog.prgbox(command,20,100, "Executing rb_init_conf")
+dialog.prgbox(command, 20, 100, "Executing rb_init_conf")

--- a/resources/scripts/rb_setup_wizard.rb
+++ b/resources/scripts/rb_setup_wizard.rb
@@ -18,7 +18,9 @@ def cancel_wizard()
     dialog.title = "SETUP wizard cancelled"
     text = <<EOF
 The setup has been cancelled or stopped.
+
 If you want to complete the setup wizard, please execute it again.
+
 EOF
     result = dialog.msgbox(text, 11, 41)
     exit(1)
@@ -31,19 +33,24 @@ general_conf = {
     "network" => {
         "interfaces" => [],
         "dns" => []
+        }
     }
-}
 
 # general_conf will dump its contents as yaml conf into rb_init_conf.yml
+
+# TODO: intro to the wizard, define color set, etc.
 
 text = <<EOF
 This wizard will guide you through the necessary configuration of the device
 in order to convert it into a redborder node within a redborder cluster.
+
 It will go through the following required steps: network configuration,
 configuration of hostname, domain and DNS, Serf configuration, and finally
 the node mode (the mode determines the minimum group of services that make up
 the node, giving it more or less weight within the cluster).
+
 Would you like to continue?
+
 EOF
 
 dialog = MRDialog.new
@@ -57,7 +64,9 @@ text = <<EOF
 Next, you will be able to configure network settings. If you have
 the network configured manually, you can "SKIP" this step and go
 to the next step.
+
 Please, Select an option.
+
 EOF
 
 dialog = MRDialog.new
@@ -107,10 +116,13 @@ end
 
     # Conf for DNS
     text = <<EOF
+
 Do you want to configure DNS servers?
+
 If you have configured the network as Dynamic and
 you get the DNS servers via DHCP, you should say
 'No' to this question.
+
 EOF
 
     dialog = MRDialog.new


### PR DESCRIPTION
## Overview
This MR implements an enhanced mechanism for selecting the management interface during network configuration.

## Changes Made

- **`rb_setup_wizard.rb`**:
  - Added logic to automatically select a static interface as the management interface if exactly one is present and others are DHCP.
  - Provided an option for the user to choose the management interface if the automatic selection criteria are not met.

- **`rb_init.rconf.rb`**:
  - Implemented initialization of the `management_interface` from `init_conf['network']` if available. This ensures the chosen management interface is set as the default interface during the setup process.

