### PR TITLE
Remove rsyslog logrotate package from redborder-proxy

### DIFF
--- a/packaging/rpm/redborder-proxy.spec
+++ b/packaging/rpm/redborder-proxy.spec
@@ -7,6 +7,7 @@ BuildArch: noarch
 Summary: Main package for redborder proxy
 
 License: AGPL 3.0
+Obsoletes: rsyslog-logrotate 
 URL: https://github.com/redBorder/redborder-proxy
 Source0: %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
* This options allows to remove Obsolete rsyslog logrotate